### PR TITLE
Improve playstyle selection UI

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -39,6 +39,18 @@ h5 { margin-top: 1rem; margin-bottom: 0.5rem; font-size: 1rem; }
 .playstyle-selector { margin-bottom: .25rem; }
 .playstyle-options { display: grid; grid-template-columns: repeat(auto-fill, minmax(150px, 1fr)); gap: .5rem 1rem; margin-top: .6rem; }
 .playstyle-options.collapsed { display: none; }
+.playstyle-options label {
+    display: flex;
+    align-items: center;
+    gap: .4rem;
+    cursor: pointer;
+    font-size: 1rem;
+}
+.playstyle-options input[type="checkbox"] {
+    width: 1.2rem;
+    height: 1.2rem;
+    accent-color: var(--accent-primary);
+}
 .toggle-playstyle-btn { background: none !important; border: none !important; box-shadow: none !important; color: var(--accent-primary); font-size: 1rem; cursor: pointer; padding: .25rem; transition: none; }
 .toggle-playstyle-btn:hover, .toggle-playstyle-btn:active { text-decoration: underline; }
 .toggle-playstyle-btn[aria-expanded="true"]::after { content: ' ▴'; }


### PR DESCRIPTION
## Summary
- enlarge playstyle checkboxes for easier clicking

## Testing
- `pytest -q`
- `python app.py & sleep 5; pkill -f app.py`

------
https://chatgpt.com/codex/tasks/task_e_6871b7d3b1788327a66c86561c80e6de